### PR TITLE
Add postinstall script to combine css

### DIFF
--- a/combine.js
+++ b/combine.js
@@ -1,0 +1,8 @@
+var fs = require('fs')
+
+var normalize = fs.createReadStream('./css/normalize.css')
+var skeleton = fs.createReadStream('./css/skeleton.css')
+var combined = fs.createWriteStream('./combined.css')
+
+normalize.pipe(combined)
+skeleton.pipe(combined)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "@scriptollc/skeleton-css",
+  "name": "skeleton-css",
   "version": "2.0.4",
   "style": "combined.css",
+  "scripts": {
+    "postinstall": "node combine.js"
+  },
   "description": "npm installer for Skeleton with normalize.css",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Export skeleton & normalize as a single CSS file for libraries like sheetify
to take advantage of it